### PR TITLE
Ntp

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,5 +15,7 @@
 - include_tasks: ipv6.yml
 # become: yes
 
+- include_tasks: ntp_pool.yml
+
 - name: flush handlers
   meta: flush_handlers

--- a/tasks/ntp_pool.yml
+++ b/tasks/ntp_pool.yml
@@ -1,0 +1,17 @@
+---
+
+## Remove ntp time pool in /etc/chrony.d/ntp-pool.sources and replace with amazon time server
+## Time synchronization server needs to be updated to 169.254.169.123
+## Secops firewall will block any other time server outside the one directly from amazon.
+
+- name: remove ntp pool and replace with amazon time server
+  replace:
+    path: /etc/chrony.d/ntp-pool.sources
+    regexp: '^pool [0-2]\.amazon\.pool\.ntp\.org iburst maxsources [1-2]'
+    replace: ''
+  
+- name: 
+  lineinfile:
+    path: /etc/chrony.d/ntp-pool.sources
+    line: 'server 169.254.169.123 prefer iburst minpoll 4 maxpoll 4'
+    insertafter: EOF

--- a/tasks/ntp_pool.yml
+++ b/tasks/ntp_pool.yml
@@ -10,7 +10,7 @@
     regexp: '^pool [0-2]\.amazon\.pool\.ntp\.org iburst maxsources [1-2]'
     replace: ''
   
-- name: 
+- name: add amazon time server to file
   lineinfile:
     path: /etc/chrony.d/ntp-pool.sources
     line: 'server 169.254.169.123 prefer iburst minpoll 4 maxpoll 4'


### PR DESCRIPTION
Chronyd time synchronization servers was updated to 169.254.169.123, this is the amazon time server for all hosts inside amazon vpc. Amazon linux eks worked perfectly with no issue with all the sectools after this update. The ntp-pool source was updated to point to amazon time server in /etc/chrony.d/ntp-pool.sources